### PR TITLE
REST pre-flight fix

### DIFF
--- a/src/Rest/Controller.php
+++ b/src/Rest/Controller.php
@@ -27,8 +27,10 @@ abstract class Controller extends BaseController {
 		// if this is an OPTIONS request, we just need to make sure corsCheck is true
 		if ($this->request->Method === 'OPTIONS') {
 			if ($corsOK) {
-				$this->response->Status = 200;
-				$this->set('success', true);
+				$preFlightCheck = new Reply(
+					200,
+					['success' => true]
+				);
 			} else {
 				$preFlightCheck = new Reply(403, ['error' => 'Not allowed']);
 			}


### PR DESCRIPTION
The pre-flight handler needs to return a Reply, not set the Response
directly, or an OPTIONS request isn’t handled properly.