### PR TITLE
Router/Controller simplification

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -66,20 +66,22 @@ abstract class Controller {
 	}
 
 	/**
-	 * Can be overridden in child classes to perform setup functions (like setting up defaults).
-	 * @param array $params
+	 * Can be overridden in child classes to perform setup functions. When using the Router,
+	 * each member of the router's $config['setupArgs'] array will be passed as method parameters,
+	 * in order of definition.
 	 * @return bool
 	 */
-	public function Setup(array $params = null) {
+	public function Setup() {
 		return true;
 	}
 
 	/**
-	 * Can be overridden in child classes to perform cleanup functions
-	 * @param array $params
+	 * Can be overridden in child classes to perform cleanup functions. When using the Router,
+	 * each member of the router's $config['cleanupArgs'] array will be passed as method parameters,
+	 * in order of definition.
 	 * @return bool
 	 */
-	public function Cleanup(array $params = null) {
+	public function Cleanup() {
 		return true;
 	}
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -108,11 +108,8 @@ class Router {
 			));
 		}
 
-		if (isset($this->config['setupArgs'])) {
-			$controller->Setup($this->config['setupArgs']);
-		} else {
-			$controller->Setup();
-		}
+		$setupArgs = (isset($this->config['setupArgs']) ? $this->config['setupArgs'] : []);
+		$this->callControllerMethodWithParams($controller, 'Setup', $setupArgs);
 
 		try {
 			$controller->Authorize($route['action']);
@@ -130,38 +127,39 @@ class Router {
 		foreach ($route['url'] as $urlParam) {
 			$actionParams[] = $urlParam;
 		}
-		switch (count($actionParams)) {
+		$this->callControllerMethodWithParams($controller, $route['action'], $actionParams);
+		$controller->Display();
+
+		$cleanupArgs = (isset($this->config['cleanupArgs']) ? $this->config['cleanupArgs'] : []);
+		$this->callControllerMethodWithParams($controller, 'Cleanup', $cleanupArgs);
+	}
+
+	protected function callControllerMethodWithParams(Controller $controller, $method, array $params) {
+		switch (count($params)) {
 			case 0:
-				$controller->$route['action']();
+				$controller->$method();
 				break;
 			case 1:
-				$controller->$route['action'](
-					$actionParams[0]
+				$controller->$method(
+					$params[0]
 				);
 				break;
 			case 2:
-				$controller->$route['action'](
-					$actionParams[0],
-					$actionParams[1]
+				$controller->$method(
+					$params[0],
+					$params[1]
 				);
 				break;
 			case 3:
-				$controller->$route['action'](
-					$actionParams[0],
-					$actionParams[1],
-					$actionParams[2]
+				$controller->$method(
+					$params[0],
+					$params[1],
+					$params[2]
 				);
 				break;
 			default:
-				call_user_func_array([$controller, $route['action']], $actionParams);
+				call_user_func_array([$controller, $method], $params);
 				break;
-		}
-		$controller->Display();
-
-		if (isset($this->config['cleanupArgs'])) {
-			$controller->Cleanup($this->config['cleanupArgs']);
-		} else {
-			$controller->Cleanup();
 		}
 	}
 


### PR DESCRIPTION
Setup() and Cleanup() will now receive the values in the Router’s
$config[‘setupArgs’] and $config[‘cleanupArgs’] respectively as method
parameters, rather than passing the entire array to the method. This is
just to make it simpler to define a Setup method (for instance) that
receives (for instance) a Container object, changing this:

```
public function Setup(array $params) {
    $this->container = $params[0];
}
```

to this:

```
public function Setup(Container $container) {
    $this-container = $container;
}
```

This should allow for more readable and maintainable code.