### PR TITLE
Remove Setup and Cleanup from Controller class

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -65,26 +65,6 @@ abstract class Controller {
 		$this->auth     = $auth;
 	}
 
-	/**
-	 * Can be overridden in child classes to perform setup functions. When using the Router,
-	 * each member of the router's $config['setupArgs'] array will be passed as method parameters,
-	 * in order of definition.
-	 * @return bool
-	 */
-	public function Setup() {
-		return true;
-	}
-
-	/**
-	 * Can be overridden in child classes to perform cleanup functions. When using the Router,
-	 * each member of the router's $config['cleanupArgs'] array will be passed as method parameters,
-	 * in order of definition.
-	 * @return bool
-	 */
-	public function Cleanup() {
-		return true;
-	}
-
 	public function Authorize($method) {
 		$authorized = true;
 		if (isset($this->auth)) {

--- a/src/Router.php
+++ b/src/Router.php
@@ -108,8 +108,10 @@ class Router {
 			));
 		}
 
-		$setupArgs = (isset($this->config['setupArgs']) ? $this->config['setupArgs'] : []);
-		$this->callControllerMethodWithParams($controller, 'Setup', $setupArgs);
+		if (method_exists($controller, 'Setup')) {
+			$setupArgs = (isset($this->config['setupArgs']) ? $this->config['setupArgs'] : []);
+			$this->callControllerMethodWithParams($controller, 'Setup', $setupArgs);
+		}
 
 		try {
 			$controller->Authorize($route['action']);
@@ -130,8 +132,10 @@ class Router {
 		$this->callControllerMethodWithParams($controller, $route['action'], $actionParams);
 		$controller->Display();
 
-		$cleanupArgs = (isset($this->config['cleanupArgs']) ? $this->config['cleanupArgs'] : []);
-		$this->callControllerMethodWithParams($controller, 'Cleanup', $cleanupArgs);
+		if (method_exists($controller, 'Cleanup')) {
+			$cleanupArgs = (isset($this->config['cleanupArgs']) ? $this->config['cleanupArgs'] : []);
+			$this->callControllerMethodWithParams($controller, 'Cleanup', $cleanupArgs);
+		}
 	}
 
 	protected function callControllerMethodWithParams(Controller $controller, $method, array $params) {

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -34,10 +34,6 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
 		unset($this->response);
 	}
 
-	public function testSetup() {
-		$this->controller->Setup();
-	}
-
 	public function testDisplay() {
 		$this->controller->Display();
 	}


### PR DESCRIPTION
Because the intention is to allow for defining custom Setup() and
Cleanup() methods that might take 0 or more parameters, defining these
methods in the abstract controller will cause a strict standards
conflict if the derived class defines more parameters.

Only call Setup and Cleanup if they exist in the class.