### PR TITLE
Auth User Mappers

### DIFF
--- a/src/Auth/BasicUserMapper.php
+++ b/src/Auth/BasicUserMapper.php
@@ -9,6 +9,6 @@ abstract class BasicUserMapper implements UserMapperInterface {
 		if (isset($this->users[$username]) && $this->users[$username] === $password) {
 			return ['username' => $username, 'password' => $password];
 		}
-		return false;
+		return null;
 	}
 }

--- a/src/Auth/Db/UserMapper.php
+++ b/src/Auth/Db/UserMapper.php
@@ -31,9 +31,9 @@ abstract class UserMapper extends Mapper implements UserMapperInterface {
 			'{'.$this->userModel->GetAuthUsernameProperty().'} = :username',
 			['username' => $username]
 		);
-		$return = false;
-		if ($user !== false) {
-			$return = ($user->IsPasswordValid($password)) ? $user : false;
+		$return = null;
+		if (isset($user)) {
+			$return = ($user->IsPasswordValid($password)) ? $user : null;
 		}
 		return $return;
 	}

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -84,7 +84,7 @@ abstract class Controller {
 				}
 				if ($requireAuth) {
 					$authUser = $this->auth->GetAuthenticatedUser();
-					if ($authUser === false) {
+					if (!isset($authUser)) {
 						// method is limited and user is not authenticated
 						throw new AccessDeniedException(sprintf(
 							'Access denied for %s',


### PR DESCRIPTION
User Mappers must return null if authentication fails, not false. This
brings them in line with the Db Mappers, which return null when results
can’t be returned rather than false.