### PR TITLE
JSON Presenter

### DIFF
--- a/src/Presenters/Json.php
+++ b/src/Presenters/Json.php
@@ -25,6 +25,12 @@ class Json implements PresenterInterface {
 	
 	private function jsonEncode($data) {
 		if (!is_array($data) && !is_object($data)) {
+			if (is_null($data)) {
+				$data = 'null';
+			}
+			if (is_bool($data)) {
+				$data = ($data) ? 'true' : 'false';
+			}
 			return json_encode(utf8_encode($data));
 		} elseif (is_object($data)) {
 			$bits = [];


### PR DESCRIPTION
If the value being encoded is a null or bool value, change them to
string values before encoding (otherwise they are empty strings).