### PR TITLE
Stricter JSON

### DIFF
--- a/src/Presenters/Json.php
+++ b/src/Presenters/Json.php
@@ -26,10 +26,10 @@ class Json implements PresenterInterface {
 	private function jsonEncode($data) {
 		if (!is_array($data) && !is_object($data)) {
 			if (is_null($data)) {
-				$data = 'null';
+				return 'null';
 			}
 			if (is_bool($data)) {
-				$data = ($data) ? 'true' : 'false';
+				return ($data) ? 'true' : 'false';
 			}
 			return json_encode(utf8_encode($data));
 		} elseif (is_object($data)) {


### PR DESCRIPTION
When encoding, if a value is null return “null” without quotes in the
JSON output. If a value is a boolean, return “true” or “false” without
quotes in the JSON output.

For example:

```
{
  “true_boolean”: true,
  “false_boolean”: false,
  “null_value”: null
}
```