### PR TITLE
Data Mapper overhaul

### DIFF
--- a/src/Auth/Db/UserMapper.php
+++ b/src/Auth/Db/UserMapper.php
@@ -36,10 +36,9 @@ class UserMapper extends Mapper implements UserMapperInterface {
 	 */
 	public function GetAuthorizedUserForUsernameAndPassword($username, $password) {
 		/** @var User $user */
-		$user = $this->GetOneWhere(
-			'{'.$this->userModel->GetAuthUsernameProperty().'} = :username',
-			['username' => $username]
-		);
+		$user = $this->GetOneWhere([
+			$this->userModel->GetAuthUsernameProperty() => $username
+		]);
 		if (isset($user)) {
 			if ($user->IsPasswordValid($password)) {
 				return $user;

--- a/src/Db/Exceptions/InvalidModelException.php
+++ b/src/Db/Exceptions/InvalidModelException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Fluxoft\Rebar\Db\Exceptions;
+
+class InvalidModelException extends \Exception {}

--- a/src/Db/Model.php
+++ b/src/Db/Model.php
@@ -14,8 +14,7 @@ abstract class Model extends BaseModel {
 	 * $propertyDbMap = [
 	 *   '{Property Name}' => [
 	 *     'col' => '{database column}',
-	 *     'type' => '{column type (PDO type)}',
-	 *     'value' => {default value}
+	 *     'type' => '{column type (PDO type)}'
 	 *   ]
 	 * ]
 	 *
@@ -37,10 +36,10 @@ abstract class Model extends BaseModel {
 	protected $idProperty = 'ID';
 
 	/**
-	 * @param array $dataRow
+	 * @param array $properties
 	 * @throws ModelException
 	 */
-	public function __construct(array $dataRow = []) {
+	public function __construct(array $properties = []) {
 		if (empty($this->propertyDbMap)) {
 			throw new ModelException(sprintf('You must specify the db column relationships in propertyDbMap'));
 		}
@@ -57,34 +56,10 @@ abstract class Model extends BaseModel {
 			unset($dbMap['value']);
 		}
 
-		// initialize the properties of this model
-		if (empty($dataRow)) {
-			// For an empty dataSet, this is a blank object. Set the ID property to 0 to indicate an
-			// uninitialized object.
-			$this->properties[$this->idProperty] = 0;
-		} else {
-			/**
-			 * Otherwise, use the values from the $dataRow to populate $this->properties using the map
-			 * provided in $this->propertyDbMap. The $dataRow can contain a partial $dataRow, but must
-			 * contain at least a value for ID. In this case, properties not included in $dataRow are left
-			 * as the default value for the property.
-			 */
-			if (!in_array($this->propertyDbMap[$this->idProperty]['col'], array_keys($dataRow))) {
-				throw new ModelException(sprintf(
-					'The given dataRow does not include a value for the ID.
-					This value is required when a dataRow is given.'
-				));
-			}
-			// Populate the properties with the given values.
-			foreach ($this->propertyDbMap as $property => &$dbMap) {
-				if (isset($dataRow[$dbMap['col']])) {
-					if ($dbMap['type'] === 'boolean') {
-						$this->properties[$property] = (boolean) $dataRow[$dbMap['col']];
-					} else {
-						$this->properties[$property] = $dataRow[$dbMap['col']];
-					}
-				}
-			}
+		parent::__construct($properties);
+
+		if (!isset($properties[$this->idProperty])) {
+			$this->{$this->idProperty} = 0;
 		}
 	}
 


### PR DESCRIPTION
This one breaks backward compatibility because of several changes to
the Db\Mapper and how SQL statements are constructed.

The Mapper can now have a custom SQL statement set that will return an
aliased list of properties, to allow for including derived fields in a
database model when retrieving models.

Filtering is now done by passing in a set of properties to be used as
filters and those are tacked on to the base selectSql string in either
a WHERE or HAVING clause, depending on whether the properties exist in
the `$propertyDbMap` or in `$properties`. (Only fields that can be
mapped to database columns should be included in `$propertyDbMap`.
Derived fields should be specified in properties).

Models can now include validation methods that will be called when
saving the object. A method named “Validate{PropertyName}” will be
called for each property, if defined. The method should return true if
validation succeeds, or an error message. If any validation method
fails, an `InvalidModelException` will be thrown rather than saving.
Validation errors can be accessed from the Model’s
`GetValidationErrors()` method.

This will be for 0.18.0