### PR TITLE
66 php 7 error class

### DIFF
--- a/src/Error/BasicNotifier.php
+++ b/src/Error/BasicNotifier.php
@@ -12,17 +12,17 @@ class BasicNotifier implements NotifierInterface {
 	 * Should be overridden in a Notifier class to accept an unhandled exception and do
 	 * something with it. These classes should be very careful to handle all possible
 	 * exceptions of their own in a graceful way so as not to cause a
-	 * @param \Exception $e
-	 * @return mixed
+	 * @param \Throwable $t
+	 * @return void
 	 */
-	public function Notify(\Exception $e) {
+	public function Notify(\Throwable $t) {
 		header('HTTP/1.1 500 Unhandled exception');
 		header('content-type: text/plain');
 		echo "******************************\n";
 		echo "***  Unhandled exception:  ***\n";
 		echo "******************************\n";
 		echo "\n";
-		echo (string) $e;
+		echo (string) $t;
 		exit;
 	}
 }

--- a/src/Error/Handler.php
+++ b/src/Error/Handler.php
@@ -26,7 +26,7 @@ class Handler {
 	public static function ErrorHandler($severity, $message, $filename, $lineno) {
 		throw new \ErrorException($message, 0, $severity, $filename, $lineno);
 	}
-	public static function ExceptionHandler(\Exception $e) {
-		self::$notifier->Notify($e);
+	public static function ExceptionHandler(\Throwable $t) {
+		self::$notifier->Notify($t);
 	}
 }

--- a/src/Error/NotifierInterface.php
+++ b/src/Error/NotifierInterface.php
@@ -7,8 +7,8 @@ interface NotifierInterface {
 	 * Should be overridden in a Notifier class to accept an unhandled exception and do
 	 * something with it. These classes should be very careful to handle all possible
 	 * exceptions of their own in a graceful way so as not to cause a
-	 * @param \Exception $e
+	 * @param \Throwable $t
 	 * @return mixed
 	 */
-	public function Notify(\Exception $e);
+	public function Notify(\Throwable $t);
 }


### PR DESCRIPTION
Notifier classes will now receive a `\Throwable` class instead of
`\Exception` in order to allow for handling new `\Error` class in PHP7