### PR TITLE
65 permanent redirect

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -99,8 +99,8 @@ class Response {
 		$this->Send();
 	}
 
-	public function Redirect($location) {
-		$this->status = 302;
+	public function Redirect($location, $permanent = false) {
+		$this->status = ($permanent) ? 301 : 302;
 		$this->AddHeader('Location', $location);
 		$this->body = '';
 		$this->Send();


### PR DESCRIPTION
If `$permanent` is set to true when calling `Response::Redirect`, send
a 301 instead of a 302.

fixes #65