### PR TITLE
error handling

### DIFF
--- a/src/Rest/Controller.php
+++ b/src/Rest/Controller.php
@@ -116,7 +116,9 @@ abstract class Controller extends BaseController {
 
 		if ($reply instanceof Reply) {
 			$this->response->Status = $reply->Status;
-			$this->set('meta', $reply->Meta);
+			if (!empty($reply->Meta)) {
+				$this->set('meta', $reply->Meta);
+			}
 			if (!empty($reply->Error)) {
 				$this->set('error', $reply->Error);
 			} else {

--- a/src/Rest/Error.php
+++ b/src/Rest/Error.php
@@ -10,12 +10,14 @@ use Fluxoft\Rebar\Model;
  * @property int Code
  * @property string Message
  * @property mixed Extra
+ * @property \Exception Exception
  */
 class Error extends Model {
 	protected $properties = [
 		'Code' => 0,
 		'Message' => '',
-		'Extra' => ''
+		'Extra' => null,
+		'Exception' => null
 	];
 
 	/**
@@ -23,18 +25,35 @@ class Error extends Model {
 	 * @param mixed $code
 	 * @param string $message
 	 * @param mixed $extra
+	 * @param \Exception $exception
 	 */
-	public function __construct($code, $message = null, $extra = null) {
+	public function __construct($code, $message = null, $extra = null, \Exception $exception = null) {
 		if (is_numeric($code) && isset($message)) {
 			parent::__construct([
 				'Code' => $code,
 				'Message' => $message,
-				'Extra' => $extra
+				'Extra' => $extra,
+				'Exception' => $exception
 			]);
 		} else {
 			parent::__construct([
 				'Message' => $code
 			]);
+		}
+	}
+
+	protected function getException() {
+		if (!isset($this->properties['Exception'])) {
+			return null;
+		} else {
+			$e = $this->properties['Exception'];
+			return [
+				'Code' => $e->getCode(),
+				'Message' => $e->getMessage(),
+				'Line' => $e->getLine(),
+				'File' => $e->getFile(),
+				'Trace' => $e->getTraceAsString()
+			];
 		}
 	}
 }


### PR DESCRIPTION
Returning more helpful end-user messages in the `Error::Message`
property.
If meta is empty, do not write it to output.
If error is for an exception, add it to `Error::Exception`