### PR TITLE
Master

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -14,11 +14,7 @@ abstract class Model implements \Iterator, \ArrayAccess {
 	protected $modProperties = [];
 
 	public function __construct(array $properties = []) {
-		if (!empty($properties)) {
-			foreach ($properties as $name => $value) {
-				$this->$name = $value;
-			}
-		}
+		$this->properties = $properties;
 	}
 
 	/**


### PR DESCRIPTION
When setting properties on a model, the $properties array should be set
directly to the values passed in rather than calling the model’s
constructors.