### PR TITLE
Set model properties in constructor using property name

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -16,7 +16,7 @@ abstract class Model implements \Iterator, \ArrayAccess {
 	public function __construct(array $properties = []) {
 		if (!empty($properties)) {
 			foreach ($properties as $name => $value) {
-				$this->properties[$name] = $value;
+				$this->{$name} = $value;
 			}
 		}
 	}


### PR DESCRIPTION
If the setter is bypassed and the properties array is directly
initialized, custom handling may be bypassed.