### PR TITLE
phpdoc setup/phpstan cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
       - run:
           name: "PHPUnit"
           command: "phpdbg -qrr vendor/bin/phpunit -c phpunit.xml.dist"
+      - run:
+          name: "PHPStan"
+          command: "vendor/bin/phpstan analyse"
       - php-coveralls/upload:
           clover-path: '${CLOVER_PATH}'
           json-path: '${JSON_PATH}'

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
 		"smarty/smarty": "^3.1",
 		"twig/twig": "^3.14",
 		"php-coveralls/php-coveralls": "^2.1",
-		"pug-php/pug": "^3.5"
+		"pug-php/pug": "^3.5",
+		"phpstan/phpstan": "^2.0"
 	},
 	"autoload": {
 		"psr-4": {"Fluxoft\\Rebar\\": "src/"}

--- a/docs/1.1-roadmap.md
+++ b/docs/1.1-roadmap.md
@@ -4,41 +4,45 @@ This is just a big general wishlist that will be revised once I actually start w
 ## Post-1.0 Enhancements
 The following features and improvements are planned for the 1.1 release of the Rebar framework:
 
-1. **Data\Caching Module**  
-   - Introduce a `Data\Caching` module to add object caching functionality to mappers.  
-   - Support integration with popular caching solutions like Redis and Memcached.  
-   - Allow configurable caching policies, such as query TTL.  
+1. **Data\Caching Module**
+   - Introduce a `Data\Caching` module to add object caching functionality to mappers.
+   - Support integration with popular caching solutions like Redis and Memcached.
+   - Allow configurable caching policies, such as query TTL.
    - Ensure pluggability for future cache backends.
 
-2. **Command and Daemon Services**  
-   - Develop a set of services inspired by the Migrant package.  
+2. **Command and Daemon Services**
+   - Develop a set of services inspired by the Migrant package.
    - Enable users to create commands and daemons with ease.
 
-3. **Application Scaffolding Commands**  
-   - Add scaffolding commands for applications:  
-     - Enable rapid application setup.  
+3. **Application Scaffolding Commands**
+   - Add scaffolding commands for applications:
+     - Enable rapid application setup.
      - Lay the groundwork for a Composer project that provides a streamlined way to bootstrap applications using Rebar.
 
-4. **Support for Additional Databases**  
+4. **Support for Additional Databases**
    - Expand database support to include SQLite, Oracle, and other engines based on demand.
 
-5. **Advanced Query Features**  
+5. **Advanced Query Features**
    - Add advanced query capabilities such as window functions and CTEs (Common Table Expressions).
 
-6. **Validation Layer**  
+6. **Validation Layer**
    - Create a robust validation system for incoming data, both at the HTTP level and in the Data\Db layer.
 
-7. **Debugging and Performance Monitoring Tools**  
-   - Provide built-in tools for debugging and monitoring application performance.  
+7. **Debugging and Performance Monitoring Tools**
+   - Provide built-in tools for debugging and monitoring application performance.
    - Consider integration with popular profiling tools.
 
-8. **Enhanced Middleware Features**  
-   - Add advanced middleware capabilities, such as:  
-     - Dynamic middleware chaining.  
+8. **Enhanced Middleware Features**
+   - Add advanced middleware capabilities, such as:
+     - Dynamic middleware chaining.
      - Error handling middleware.
 
-9. **Authentication Enhancements**  
+9. **Authentication Enhancements**
    - Extend authentication mechanisms to support OAuth2, OpenID Connect, and SSO integrations.
 
-10. **Testing Utilities**  
+10. **Testing Utilities**
     - Add utilities to simplify writing tests for Rebar applications, including mock generators and testing helpers.
+
+11. **CORS Header Safety**
+    - Revisit the handling of `Access-Control-Allow-Headers` to ensure a balance between security and flexibility.
+    - Consider implementing a default whitelist of common headers and evaluate risks of allowing all headers.

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+        configVersion="3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://www.phpdoc.org"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/phpDocumentor/phpDocumentor/master/data/xsd/phpdoc.xsd"
+>
+    <paths>
+        <output>build/api</output>
+        <cache>build/cache</cache>
+    </paths>
+    <version number="3.0.0">
+        <api>
+            <source dsn=".">
+                <path>src</path>
+            </source>
+        </api>
+    </version>
+</phpdocumentor>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,14 @@
+# phpstan.neon
+parameters:
+    level: 2 # Adjust strictness level from 0 (least strict) to 9 (most strict)
+    paths:
+        - src/ # Analyze your source code
+    bootstrapFiles:
+        - vendor/autoload.php # Ensure Composer autoloader is included
+    excludePaths:
+        # Use regex to exclude specific paths
+        - %currentWorkingDirectory%/tests/* # Exclude test files
+    ignoreErrors:
+        # Suppress specific error patterns (add only if necessary)
+        # Example:
+        # - '#Call to an undefined method#'

--- a/src/Auth/ApiAuth.php
+++ b/src/Auth/ApiAuth.php
@@ -16,7 +16,7 @@ class ApiAuth extends BaseAuth {
 		$authReply = new Reply();
 
 		// Retrieve the Authorization header
-		$authorizationHeader = $request->Headers->Get('Authorization');
+		$authorizationHeader = $request->Headers('Authorization');
 		if (!isset($authorizationHeader) || stripos($authorizationHeader, 'Bearer ') !== 0) {
 			$authReply->Auth    = false;
 			$authReply->Message = 'Missing or invalid Authorization header.';
@@ -65,11 +65,11 @@ class ApiAuth extends BaseAuth {
 		$authReply = new Reply();
 
 		// Check for a global logout flag
-		$globalLogout = (bool) $request->Get->Get('globalLogout', false);
+		$globalLogout = (bool) $request->Get('globalLogout', false);
 
 		if ($globalLogout) {
 			// Retrieve the Authorization header
-			$authorizationHeader = $request->Headers->Get('Authorization');
+			$authorizationHeader = $request->Headers('Authorization');
 			if (!isset($authorizationHeader) || stripos($authorizationHeader, 'Bearer ') !== 0) {
 				$authReply->Auth    = false;
 				$authReply->Message = 'Missing or invalid Authorization header.';
@@ -106,7 +106,7 @@ class ApiAuth extends BaseAuth {
 			$request->Cookies->Delete('RefreshToken');
 		} else {
 			// Check for a refresh token in the headers
-			$refreshToken = $request->Headers->Get('RefreshToken');
+			$refreshToken = $request->Headers('RefreshToken');
 		}
 
 		// If we still don't have a refresh token, we can't revoke it

--- a/src/Auth/BasicAuth.php
+++ b/src/Auth/BasicAuth.php
@@ -21,12 +21,12 @@ class BasicAuth implements AuthInterface {
 	 * {@inheritdoc}
 	 */
 	public function GetAuthenticatedUser(Request $request): ?Reply {
-		$basicAuthUser = $request->Server->Get('PHP_AUTH_USER');
+		$basicAuthUser = $request->Server('PHP_AUTH_USER');
 
 		if (!isset($basicAuthUser)) {
 			throw new BasicAuthChallengeException($this->realm, $this->message);
 		}
-		return $this->Login($request, $basicAuthUser, $request->Server->Get('PHP_AUTH_PW', ''));
+		return $this->Login($request, $basicAuthUser, $request->Server('PHP_AUTH_PW', ''));
 	}
 
 	/**
@@ -36,7 +36,7 @@ class BasicAuth implements AuthInterface {
 	public function Login(Request $request, string $username, string $password, bool $remember = false): Reply {
 		// unused in this implementation
 		unset($request, $remember);
-		
+
 		$reply       = new Reply();
 		$user        = $this->userMapper->GetAuthorizedUserForUsernameAndPassword($username, $password);
 		$reply->Auth = true;

--- a/src/Auth/Exceptions/UserMapperException.php
+++ b/src/Auth/Exceptions/UserMapperException.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace Fluxoft\rebar\Auth\Exceptions;
+namespace Fluxoft\Rebar\Auth\Exceptions;
 
 class UserMapperException extends \Exception {}

--- a/src/Auth/RefreshToken.php
+++ b/src/Auth/RefreshToken.php
@@ -6,14 +6,14 @@ use Fluxoft\Rebar\Model;
 
 /**
  * Class RefreshToken
- * @package Fluxoft\Rebar\Auth
- * @property int Id
- * @property int UserId
- * @property int SeriesId
- * @property string Token
- * @property string ExpiresAt
- * @property string CreatedAt
- * @property string RevokedAt
+ * A model for a refresh token.
+ * @property int $Id
+ * @property int $UserId
+ * @property int $SeriesId
+ * @property string $Token
+ * @property string $ExpiresAt
+ * @property string $CreatedAt
+ * @property string $RevokedAt
  */
 class RefreshToken extends Model {
 	protected static array $defaultProperties = [

--- a/src/Auth/Reply.php
+++ b/src/Auth/Reply.php
@@ -9,12 +9,12 @@ use Fluxoft\Rebar\Model;
  * Returned by Auth classes implementations of AuthInterface::Login and
  * AuthInterface::GetAuthenticatedUser
  * @package Fluxoft\rebar\Auth
- * @property bool Auth True if the user is authenticated
- * @property mixed User
- * @property string AccessToken
- * @property string RefreshToken
- * @property string Message
- * @property array  Claims User claims fro the access token
+ * @property bool   $Auth True if the user is authenticated
+ * @property mixed  $User
+ * @property string $AccessToken
+ * @property string $RefreshToken
+ * @property string $Message
+ * @property array  $Claims User claims fro the access token
  */
 class Reply extends Model {
 	public function __construct() {

--- a/src/Auth/Simple/User.php
+++ b/src/Auth/Simple/User.php
@@ -9,9 +9,9 @@ use Fluxoft\Rebar\Model;
 /**
  * Class User
  * @package Fluxoft\Rebar\Auth\Users\Simple
- * @property int Id
- * @property string Username
- * @property string Password
+ * @property int    $Id
+ * @property string $Username
+ * @property string $Password
  */
 class User extends Model implements UserInterface {
 	protected array $properties = [

--- a/src/Auth/Simple/UserMapper.php
+++ b/src/Auth/Simple/UserMapper.php
@@ -42,10 +42,7 @@ class UserMapper implements UserMapperInterface {
 
 	/**
 	 * Return the user for the given username and password.
-	 * @param $username
-	 * @param $password
-	 * @return mixed
-	 * @throws InvalidPasswordException
+	 * @throws InvalidCredentialsException
 	 * @throws UserNotFoundException
 	 */
 	public function GetAuthorizedUserForUsernameAndPassword(string $username, string $password): UserInterface {
@@ -71,8 +68,6 @@ class UserMapper implements UserMapperInterface {
 
 	/**
 	 * Return the user for the given ID
-	 * @param $id
-	 * @return mixed
 	 * @throws UserNotFoundException
 	 */
 	public function GetAuthorizedUserById(mixed $id): UserInterface {
@@ -98,7 +93,7 @@ class UserMapper implements UserMapperInterface {
 			throw new \RuntimeException(sprintf('Failed to save users to file: %s', $filePath));
 		}
 	}
-	
+
 	public function LoadFromFile(string $filePath): void {
 		if (!file_exists($filePath)) {
 			throw new \RuntimeException(sprintf('File not found: %s', $filePath));
@@ -109,6 +104,6 @@ class UserMapper implements UserMapperInterface {
 			throw new \RuntimeException(sprintf('Failed to load users from file: %s', $filePath));
 		}
 		$this->users = $users;
-	}	
+	}
 	// @codeCoverageIgnoreEnd
 }

--- a/src/Data/Db/Filter.php
+++ b/src/Data/Db/Filter.php
@@ -9,9 +9,9 @@ use Fluxoft\Rebar\Data\Db\Exceptions\InvalidFilterException;
 use Fluxoft\Rebar\Data\FilterInterface;
 
 /**
- * @property string Property
- * @property string Operator
- * @property mixed  Value
+ * @property string $Property
+ * @property string $Operator
+ * @property mixed  $Value
  */
 final class Filter implements FilterInterface, \ArrayAccess, \Iterator {
 	use GettableProperties;

--- a/src/Data/Db/Join.php
+++ b/src/Data/Db/Join.php
@@ -9,10 +9,10 @@ use Fluxoft\Rebar\_Traits\SettableProperties;
  * Class Join
  * This class represents a SQL JOIN clause, defining its type, table, and condition.
  * @package Fluxoft\Rebar\Db
- * @property string Type The type of join (e.g., INNER, LEFT).
- * @property string Table The table to join.
- * @property string On The ON clause for the join condition.
- * @property string|null Alias The alias for the joined table.
+ * @property string  $Type The type of join (e.g., INNER, LEFT).
+ * @property string  $Table The table to join.
+ * @property string  $On The ON clause for the join condition.
+ * @property ?string $Alias The alias for the joined table.
  */
 final class Join {
 	use GettableProperties;

--- a/src/Data/Db/Mappers/GenericSql.php
+++ b/src/Data/Db/Mappers/GenericSql.php
@@ -223,7 +223,7 @@ abstract class GenericSql implements MapperInterface {
 	/**
 	 * Format an identifier for use in SQL
 	 * This method can be overridden in the extending class if the database server requires
-	 * @param string $identifier
+	 * @param string $element
 	 * @return string
 	 */
 	protected function quoteElement(string $element): string {
@@ -273,7 +273,6 @@ abstract class GenericSql implements MapperInterface {
 	/**
 	 * Create a new record in the database.
 	 * @param Model $model
-	 * @throws Exception
 	 */
 	protected function performCreate(Model $model): void {
 		$properties = array_intersect_key(
@@ -292,7 +291,6 @@ abstract class GenericSql implements MapperInterface {
 	/**
 	 * Update an existing record in the database.
 	 * @param Model $model
-	 * @throws Exception
 	 */
 	protected function performUpdate(Model $model): void {
 		$properties = array_intersect_key(
@@ -327,7 +325,6 @@ abstract class GenericSql implements MapperInterface {
 	/**
 	 * Delete a record from the database.
 	 * @param array $conditions
-	 * @throws Exception
 	 */
 	protected function performDelete(array $conditions): void {
 		// Generate SQL and params using the helper
@@ -343,7 +340,7 @@ abstract class GenericSql implements MapperInterface {
 	 * @param string $sql
 	 * @param array $params
 	 * @param bool $fetch Whether to fetch the results or not
-	 * @return array|null
+	 * @return ?array
 	 */
 	protected function executeQuery(PDO $dbConnection, string $sql, array $params, bool $fetch = false): ?array {
 		try {
@@ -579,10 +576,7 @@ abstract class GenericSql implements MapperInterface {
 	}
 
 	/**
-	 * Determine if there are aggregates in the SELECT clause or filters.
-	 *
-	 * @param array $filters
-	 * @return bool
+	 * Determine if there are aggregates in the SELECT clause.
 	 */
 	protected function hasAggregatesInSelect(): bool {
 		foreach ($this->propertyDbMap as $propertyObject) {
@@ -596,7 +590,6 @@ abstract class GenericSql implements MapperInterface {
 	/**
 	 * Add a GROUP BY clause to the SQL statement if there are aggregates in the select.
 	 * @param string $sql
-	 * @param Filter[] $filters
 	 */
 	protected function applyGrouping(string $sql): string {
 		if ($this->hasAggregatesInSelect()) {

--- a/src/Data/Db/Mappers/MapperInterface.php
+++ b/src/Data/Db/Mappers/MapperInterface.php
@@ -2,6 +2,8 @@
 
 namespace Fluxoft\Rebar\Data\Db\Mappers;
 
+use Fluxoft\Rebar\Data\Db\Filter;
+use Fluxoft\Rebar\Data\Db\Sort;
 use Fluxoft\Rebar\Model;
 
 interface MapperInterface {
@@ -9,13 +11,27 @@ interface MapperInterface {
 	public function GetOneById(int $id): ?Model;
 	/**
 	 * @param Filter[] $filters
-	 * @return Model|null
+	 * @return ?Model
 	 */
 	public function GetOne(array $filters): ?Model;
+	/**
+	 * @param Filter[] $filters
+	 * @param Sort[] $sort
+	 * @param int $page
+	 * @param int $pageSize
+	 * @return Model[]
+	 */
 	public function GetSet(array $filters = [], array $sort = [], int $page = 1, int $pageSize = 0): array;
+	/**
+	 * @param Filter[] $filters
+	 * @return int
+	 */
 	public function Count(array $filters = []): int;
 	public function Delete(Model &$model): void;
 	public function DeleteById(int $id): void;
+	/**
+	 * @param Filter[] $filters
+	 */
 	public function DeleteOneWhere(array $filters): void;
 	public function Save(Model $model): void;
 }

--- a/src/Data/Db/Property.php
+++ b/src/Data/Db/Property.php
@@ -7,11 +7,11 @@ namespace Fluxoft\Rebar\Data\Db;
  * This class is a property mapper, used to map properties to database columns.
  * It can be used to implement property-specific logic as needed.
  * @package Fluxoft\Rebar\Db
- * @property string Column
- * @property string Type
- * @property-read bool IsWriteable
- * @property-read bool IsAggregate
- * @property-read bool IsSubquery
+ * @property string    $Column
+ * @property string    $Type
+ * @property-read bool $IsWriteable
+ * @property-read bool $IsAggregate
+ * @property-read bool $IsSubquery
  */
 final class Property {
 	use \Fluxoft\Rebar\_Traits\GettableProperties;

--- a/src/Data/Db/Sort.php
+++ b/src/Data/Db/Sort.php
@@ -10,8 +10,8 @@ use Fluxoft\Rebar\Data\SortInterface;
 /**
  * Class Sort
  * @package Fluxoft\Rebar\Data\Db
- * @property string Property
- * @property string Direction
+ * @property string $Property
+ * @property string $Direction
  */
 final class Sort implements SortInterface, \ArrayAccess, \Iterator {
 	use GettableProperties;

--- a/src/Http/AbstractRestController.php
+++ b/src/Http/AbstractRestController.php
@@ -68,13 +68,13 @@ abstract class AbstractRestController extends Controller {
 						// Fetch single model
 						$responseData = ['data' => $this->service->Fetch($id)];
 					} else {
-						$pageParams = $this->request->Get->Get('page', []);
-						$page       = (int) ($pageParams['number'] ?? $this->request->Get->Get('page', 1));
-						$pageSize   = (int) ($pageParams['size'] ?? $this->request->Get->Get('pageSize', 20));
+						$pageParams = $this->request->Get('page', []);
+						$page       = (int) ($pageParams['number'] ?? $this->request->Get('page', 1));
+						$pageSize   = (int) ($pageParams['size'] ?? $this->request->Get('pageSize', 20));
 
-						$filterParams = $this->request->Get->Get('filter', []);
-						$sortParams   = $this->request->Get->Get('sort', []);
-						
+						$filterParams = $this->request->Get('filter', []);
+						$sortParams   = $this->request->Get('sort', []);
+
 						$responseData = [
 							'data' => $this->service->FetchAll($filterParams, $sortParams, $page, $pageSize),
 							'meta' => [
@@ -87,7 +87,7 @@ abstract class AbstractRestController extends Controller {
 					break;
 
 				case 'POST': // @codeCoverageIgnore
-					$data         = $this->request->Post->Get();
+					$data         = $this->request->Post();
 					$responseData = ['data' => $this->service->Create($data)];
 					$status       = 201;
 					break;
@@ -96,7 +96,7 @@ abstract class AbstractRestController extends Controller {
 					if ($id === null) {
 						throw new \InvalidArgumentException('ID parameter is required for PUT.');
 					}
-					$data         = $this->request->Post->Get();
+					$data         = $this->request->Post();
 					$responseData = ['data' => $this->service->Update($id, $data)];
 					break;
 

--- a/src/Http/Controller.php
+++ b/src/Http/Controller.php
@@ -20,14 +20,14 @@ abstract class Controller {
 	 * The presenter property determines which presenter class
 	 * will be used to render the display.
 	 *
-	 * @var \Fluxoft\Rebar\Presenters\PresenterInterface $presenter
+	 * @var PresenterInterface $presenter
 	 */
 	protected $presenter = null;
 	/**
 	 * @var null|string The name of a class implementing PresenterInterface that
 	 * should be used for setting the presenter if no other presenter has been set.
 	 * Either a fully-qualified class name should be given or a Presenter that can be
-	 * found in the \Fluxoft\Rebar\Presenters namespace should be used.
+	 * found in the \Fluxoft\Rebar\Http\Presenters namespace should be used.
 	 */
 	protected $presenterClass = null;
 	/**
@@ -41,7 +41,6 @@ abstract class Controller {
 	 * Controller constructor.
 	 * @param Request $request
 	 * @param Response $response
-	 * @param AuthInterface|null $auth
 	 */
 	public function __construct(
 		protected Request $request,

--- a/src/Http/Cookies.php
+++ b/src/Http/Cookies.php
@@ -34,7 +34,6 @@ class Cookies extends ParameterSet {
 	 * Use $overrides to override the default settings, if needed.
 	 * @param string $key
 	 * @param mixed  $value
-	 * @param int    $expires
 	 * @param array  $overrides Settings overrides, valid keys are: expires, path, domain, secure, httponly
 	 */
 	public function Set(

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -42,7 +42,7 @@ class Environment implements \ArrayAccess, \Iterator {
 
 	public static function GetInstance(): Environment {
 		if (is_null(static::$environment)) {
-			static::$environment = new self();
+			static::$environment = new static();
 		}
 		return static::$environment;
 	}
@@ -56,7 +56,7 @@ class Environment implements \ArrayAccess, \Iterator {
 		'secure'   => null, // Will be dynamically set in the constructor
 		'httponly' => true // Default to HTTP-only cookies for security
 	];
-	private function __construct() {
+	final private function __construct() {
 		$this->defaultCookieSettings['domain'] = $this->ServerParams['HTTP_HOST'] ?? null;
 		$this->defaultCookieSettings['secure'] = isset($this->ServerParams['HTTPS']) &&
 			$this->ServerParams['HTTPS'] !== 'off';

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -42,7 +42,7 @@ class Environment implements \ArrayAccess, \Iterator {
 
 	public static function GetInstance(): Environment {
 		if (is_null(static::$environment)) {
-			static::$environment = new static();
+			static::$environment = new self();
 		}
 		return static::$environment;
 	}

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -12,15 +12,15 @@ use Fluxoft\Rebar\Http\Exceptions\EnvironmentException;
 /**
  * Class Environment
  * @package Fluxoft\Rebar\Http
- * @property-read array ServerParams This is the $_SERVER superglobal
- * @property-read array GetParams This is the $_GET superglobal
- * @property-read array PostParams This is the $_POST superglobal
- * @property-read array PutParams This is the $_POST superglobal, but only if the request method is PUT
- * @property-read array PatchParams This is the $_POST superglobal, but only if the request method is PATCH
- * @property-read array DeleteParams This is the $_POST superglobal, but only if the request method is DELETE
- * @property-read array Headers This is an array of all headers sent in the request
- * @property-read string Input This is the raw input from the request
- * @property array CookieSettings This is an array of settings for cookies, valid keys are:
+ * @property-read array  $ServerParams This is the $_SERVER superglobal
+ * @property-read array  $GetParams This is the $_GET superglobal
+ * @property-read array  $PostParams This is the $_POST superglobal
+ * @property-read array  $PutParams This is the $_POST superglobal, but only if the request method is PUT
+ * @property-read array  $PatchParams This is the $_POST superglobal, but only if the request method is PATCH
+ * @property-read array  $DeleteParams This is the $_POST superglobal, but only if the request method is DELETE
+ * @property-read array  $Headers This is an array of all headers sent in the request
+ * @property-read string $Input This is the raw input from the request
+ * @property      array  $CookieSettings This is an array of settings for cookies, valid keys are:
  *  - expires: The expiration time of the cookie. Default is 0 (session cookie)
  *  - path: The path on the server in which the cookie will be available on. Default is '/'
  *  - domain: The (sub)domain that the cookie is available to. Default is the host of the server
@@ -140,7 +140,7 @@ class Environment implements \ArrayAccess, \Iterator {
 		}
 		return $this->properties['Input'];
 	}
-	
+
 	// CookieSettings
 	public function SetCookieSettings(array $settings): void {
 		$this->properties['CookieSettings'] = $this->validateCookieSettings($settings);

--- a/src/Http/Middleware/Cors.php
+++ b/src/Http/Middleware/Cors.php
@@ -24,7 +24,6 @@ class Cors implements MiddlewareInterface {
 
 	public function Process(Request $request, Response $response, callable $next): Response {
 		$allowedMethods = array_map('strtoupper', $this->allowedMethods);
-		$requestHeaders = $request->Headers;
 		$requestMethod  = $request->Method;
 
 		// always allow OPTIONS requests
@@ -34,9 +33,10 @@ class Cors implements MiddlewareInterface {
 
 		// set CORS headers if configured
 		if ($this->crossOriginEnabled) {
-			if (isset($requestHeaders['Origin'])) {
-				$allowedHeaders = ($requestHeaders['Access-Control-Request-Headers'] ?? '');
-				$origin         = $requestHeaders['Origin'];
+			$origin = $request->Headers('Origin');
+			if (isset($origin)) {
+				$allowedHeaders = $request->Headers('Access-Control-Request-Headers', '');
+				$origin         = $request->Headers('Origin');
 				if (in_array($origin, $this->crossOriginDomainsAllowed)) {
 					$response->AddHeader('Access-Control-Allow-Origin', $origin);
 					$response->AddHeader('Access-Control-Allow-Credentials', 'true');

--- a/src/Http/Presenters/Phtml.php
+++ b/src/Http/Presenters/Phtml.php
@@ -16,15 +16,15 @@ use Fluxoft\Rebar\Http\Response;
  * transitioned at one time.
  *
  * @package Fluxoft\Rebar\Presenters
- * @property string Layout
- * @property string Template
+ * @property string $Layout
+ * @property string $Template
  */
 class Phtml implements PresenterInterface {
 	public function __construct(
 		private readonly string $templatePath,
 		private string $template = '/default.phtml',
 		private string $layout = ''
-	) {}	
+	) {}
 
 	/**
 	 * Render the given data using the specified template or layout.
@@ -80,10 +80,10 @@ class Phtml implements PresenterInterface {
 		if (!$this->fileExists($include)) {
 			return null; // Return null if the file doesn't exist
 		}
-	
+
 		// Extract variables into the scope of the template
 		extract($variables);
-	
+
 		ob_start();
 		include $include;
 		return ob_get_clean();

--- a/src/Http/Presenters/Pug.php
+++ b/src/Http/Presenters/Pug.php
@@ -8,7 +8,7 @@ use Fluxoft\Rebar\Http\Response;
 /**
  * Class Pug
  * @package Fluxoft\Rebar\Presenters
- * @property string Template
+ * @property string $Template
  */
 class Pug implements PresenterInterface {
 	protected string $template;

--- a/src/Http/Presenters/Smarty.php
+++ b/src/Http/Presenters/Smarty.php
@@ -8,8 +8,8 @@ use \Fluxoft\Rebar\Http\Response;
 /**
  * Class Smarty
  * @package Fluxoft\Rebar\Presenters
- * @property string Layout
- * @property string Template
+ * @property string $Layout
+ * @property string $Template
  */
 class Smarty implements PresenterInterface {
 	public function __construct(
@@ -21,9 +21,9 @@ class Smarty implements PresenterInterface {
 
 	public function Render(Response $response, array $data): void {
 		$this->smarty->assign($data);
-	
+
 		$templatePath = rtrim($this->templatePath, '/') . '/';
-	
+
 		if ($this->layout !== '') {
 			$this->smarty->assign('templateFile', $templatePath . ltrim($this->template, '/'));
 			$template = $templatePath . ltrim($this->layout, '/');
@@ -31,11 +31,11 @@ class Smarty implements PresenterInterface {
 			$template = $templatePath . ltrim($this->template, '/');
 		}
 		$output = $this->smarty->fetch($template);
-	
+
 		$response->Body = $output;
 		$response->Send();
 	}
-	
+
 	public function __set($var, $val) {
 		switch ($var) {
 			case 'Template': // @codeCoverageIgnore

--- a/src/Http/Presenters/Twig.php
+++ b/src/Http/Presenters/Twig.php
@@ -8,8 +8,8 @@ use Twig\Environment;
 /**
  * Class Twig
  * @package Fluxoft\Rebar\Presenters
- * @property string Layout
- * @property string Template
+ * @property string $Layout
+ * @property string $Template
  */
 class Twig implements PresenterInterface {
 	public function __construct(

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -9,28 +9,28 @@ use Fluxoft\Rebar\Auth\UserInterface;
 /**
  * Class Request
  * @package Fluxoft\Rebar\Http
- * @property AuthInterface|null Auth              The auth module for this request, if any.
- * @property UserInterface|null AuthenticatedUser The authenticated user for this request, if any.
- * @property-read string Method   The HTTP method of the request (GET, POST, PUT, DELETE, etc.)
- * @property-read string Protocol Protocol used for the request (http, https, etc.)
- * @property-read string Host     Hostname of the request
- * @property-read int    Port     Port of the request
- * @property-read string URL      Full URL of the request
- * @property-read string URI      URI of the request
- * @property-read string Path     Path of the request
- * @property-read string RemoteIP IP address of the remote client
- * @property-read string RawBody  Raw body of the request. Immutable once set.
- * @property string Body     Body of the request. Mutable.
- * @property-read Session|null Session Session object for the request
- * @property-read Cookies|null Cookies Cookies object for the request
- * 
- * @method string Server(string $var = null, string $default = null) Retrieves one or all server parameters.
- * @method string Headers(string $var = null, string $default = null) Retrieves one or all headers.
- * @method string Get(string $var = null, string $default = null) Retrieves one or all GET parameters.
- * @method string Post(string $var = null, string $default = null) Retrieves one or all POST parameters.
- * @method string Put(string $var = null, string $default = null) Retrieves one or all PUT parameters.
- * @method string Patch(string $var = null, string $default = null) Retrieves one or all PATCH parameters.
- * @method string Delete(string $var = null, string $default = null) Retrieves one or all DELETE parameters.
+ * @property AuthInterface|null $Auth              The auth module for this request, if any.
+ * @property UserInterface|null $AuthenticatedUser The authenticated user for this request, if any.
+ * @property-read string $Method   The HTTP method of the request (GET, POST, PUT, DELETE, etc.)
+ * @property-read string $Protocol Protocol used for the request (http, https, etc.)
+ * @property-read string $Host     Hostname of the request
+ * @property-read int    $Port     Port of the request
+ * @property-read string $URL      Full URL of the request
+ * @property-read string $URI      URI of the request
+ * @property-read string $Path     Path of the request
+ * @property-read string $RemoteIP IP address of the remote client
+ * @property-read string $RawBody  Raw body of the request. Immutable once set.
+ * @property string      $Body     Body of the request. Mutable.
+ * @property-read Session|null $Session Session object for the request
+ * @property-read Cookies|null $Cookies Cookies object for the request
+ *
+ * @method ?string Server(string $var = null, ?string $default = null) Retrieves one or all server parameters.
+ * @method ?string Headers(string $var = null, ?string $default = null) Retrieves one or all headers.
+ * @method ?string Get(string $var = null, ?string $default = null) Retrieves one or all GET parameters.
+ * @method ?string Post(string $var = null, ?string $default = null) Retrieves one or all POST parameters.
+ * @method ?string Put(string $var = null, ?string $default = null) Retrieves one or all PUT parameters.
+ * @method ?string Patch(string $var = null, ?string $default = null) Retrieves one or all PATCH parameters.
+ * @method ?string Delete(string $var = null, ?string $default = null) Retrieves one or all DELETE parameters.
  */
 class Request {
 	use GettableProperties;
@@ -44,13 +44,13 @@ class Request {
 	private ParameterSet $putParamSet;
 	private ParameterSet $patchParamSet;
 	private ParameterSet $deleteParamSet;
-	
+
 	/**
 	 * Request constructor.
 	 * Sets up the request object with the environment.
 	 * Also sets up the properties array with the default properties. All properties are null by default,
 	 * except for RawBody, which is set to the raw input from the environment (which can only be read once).
-	 * 
+	 *
 	 * @param Environment $environment
 	 */
 	public function __construct(Environment $environment) {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -8,10 +8,10 @@ use InvalidArgumentException;
 /**
  * Class Response
  * @package Fluxoft\Rebar\Http
- * @property int Status
- * @property string StatusMessage
- * @property string Body
- * @property array Headers
+ * @property int    $Status
+ * @property string $StatusMessage
+ * @property string $Body
+ * @property array  $Headers
  */
 class Response {
 	use GettableProperties;
@@ -23,7 +23,7 @@ class Response {
 		101 => 'Switching Protocols',
 		102 => 'Processing', // WebDAV
 		103 => 'Early Hints',
-	
+
 		// Successful 2xx
 		200 => 'OK',
 		201 => 'Created',
@@ -35,7 +35,7 @@ class Response {
 		207 => 'Multi-Status', // WebDAV
 		208 => 'Already Reported', // WebDAV
 		226 => 'IM Used',
-	
+
 		// Redirection 3xx
 		300 => 'Multiple Choices',
 		301 => 'Moved Permanently',
@@ -45,7 +45,7 @@ class Response {
 		305 => 'Use Proxy',
 		307 => 'Temporary Redirect',
 		308 => 'Permanent Redirect',
-	
+
 		// Client Error 4xx
 		400 => 'Bad Request',
 		401 => 'Unauthorized',
@@ -76,7 +76,7 @@ class Response {
 		429 => 'Too Many Requests',
 		431 => 'Request Header Fields Too Large',
 		451 => 'Unavailable For Legal Reasons',
-	
+
 		// Server Error 5xx
 		500 => 'Internal Server Error',
 		501 => 'Not Implemented',
@@ -90,7 +90,7 @@ class Response {
 		510 => 'Not Extended',
 		511 => 'Network Authentication Required'
 	];
-	
+
 
 	public function __construct(
 		int $status = 200,

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -7,9 +7,9 @@ use Fluxoft\Rebar\Model;
 /**
  * Class Route
  * @package Fluxoft\Rebar
- * @property string Path
- * @property string Controller
- * @property string Action
+ * @property string $Path
+ * @property string $Controller
+ * @property string $Action
  */
 class Route extends Model {
 	/**

--- a/tests/Auth/ApiAuthTest.php
+++ b/tests/Auth/ApiAuthTest.php
@@ -3,7 +3,7 @@
 namespace Fluxoft\Rebar\Auth;
 
 use Fluxoft\Rebar\Auth\Exceptions\InvalidTokenException;
-use Fluxoft\Rebar\Http\ParameterSet;
+use Fluxoft\Rebar\Http\Cookies;
 use Fluxoft\Rebar\Http\Request;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -17,11 +17,7 @@ class ApiAuthTest extends TestCase {
 	private $userObserver;
 	/** @var Request|MockObject */
 	private $requestObserver;
-	/** @var ParameterSet|MockObject */
-	private $headersParamSet;
-	/** @var ParameterSet|MockObject */
-	private $getParamSet;
-	/** @var ParameterSet|MockObject */
+	/** @var Cookies|MockObject */
 	private $cookiesParamSet;
 
 	protected function setup(): void {
@@ -29,32 +25,20 @@ class ApiAuthTest extends TestCase {
 			->getMock();
 		$this->userObserver         = $this->getMockBuilder('\Fluxoft\Rebar\Auth\UserInterface')
 			->getMock();
-		$this->headersParamSet      = $this->getMockBuilder('\Fluxoft\Rebar\Http\ParameterSet')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->getParamSet          = $this->getMockBuilder('\Fluxoft\Rebar\Http\ParameterSet')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->cookiesParamSet      = $this->getMockBuilder('\Fluxoft\Rebar\Http\ParameterSet')
+		$this->cookiesParamSet      = $this->getMockBuilder('\Fluxoft\Rebar\Http\Cookies')
 			->disableOriginalConstructor()
 			->getMock();
 		$this->tokenManagerObserver = $this->getMockBuilder('\Fluxoft\Rebar\Auth\TokenManager')
 			->disableOriginalConstructor()
-			->getMock();	
+			->getMock();
 		$this->requestObserver      = $this->getMockBuilder('\Fluxoft\Rebar\Http\Request')
 			->disableOriginalConstructor()
 			->getMock();
-	
+
 		// Mock the Request::__get method to return the Headers parameter set
 		$this->requestObserver
 			->method('__get')
 			->willReturnCallback(function ($key) {
-				if ($key === 'Headers') {
-					return $this->headersParamSet;
-				}
-				if ($key === 'Get') {
-					return $this->getParamSet;
-				}
 				if ($key === 'Cookies') {
 					return $this->cookiesParamSet;
 				}
@@ -67,43 +51,38 @@ class ApiAuthTest extends TestCase {
 			$this->userMapperObserver,
 			$this->tokenManagerObserver,
 			$this->userObserver,
-			$this->requestObserver,
-			$this->headersParamSet
+			$this->requestObserver
 		);
 	}
 
 	public function testGetAuthenticatedUserWithValidToken() {
 		$claims = ['userId' => 1];
-	
+
 		// Set the Authorization header to 'Bearer valid-token'
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'Authorization') {
-					return 'Bearer valid-token'; // Ensure it returns 'valid-token'
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('Authorization')
+			->willReturn('Bearer valid-token');
+
 		// Mock the TokenManager to decode the token and return claims
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('DecodeAccessToken')
 			->with('valid-token')
 			->willReturn($claims);
-	
+
 		// Mock the UserMapper to return a User object
 		$this->userMapperObserver
 			->expects($this->once())
 			->method('GetAuthorizedUserById')
 			->with(1)
 			->willReturn($this->userObserver);
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		// Call the method under test
 		$reply = $auth->GetAuthenticatedUser($this->requestObserver);
-	
+
 		// Assert the expected behavior
 		$this->assertTrue($reply->Auth, 'Expected Auth to be true.');
 		$this->assertSame($this->userObserver, $reply->User, 'Expected the User to match.');
@@ -113,110 +92,90 @@ class ApiAuthTest extends TestCase {
 
 	public function testGetAuthenticatedUserWithInvalidToken() {
 		// Override Authorization header mock for invalid token
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'Authorization') {
-					return 'Bearer invalid-token'; // Ensure it returns 'invalid-token'
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('Authorization')
+			->willReturn('Bearer invalid-token');
+
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('DecodeAccessToken')
 			->with('invalid-token')
 			->willThrowException(new InvalidTokenException('Invalid or expired token'));
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->GetAuthenticatedUser($this->requestObserver);
-	
+
 		$this->assertFalse($reply->Auth);
 		$this->assertEquals('Invalid or expired token', $reply->Message);
 	}
 
 	public function testGetAuthenticatedUserWithMissingHeader() {
 		// Mock empty Authorization header
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'Authorization') {
-					return null; // Simulate missing header
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('Authorization')
+			->willReturn(null);
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->GetAuthenticatedUser($this->requestObserver);
-	
+
 		$this->assertFalse($reply->Auth);
 		$this->assertEquals('Missing or invalid Authorization header.', $reply->Message);
 	}
 
 	public function testLogoutWithGlobalFlag() {
-		$this->getParamSet
+		// Mock the globalLogout parameter
+		$this->requestObserver
 			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'globalLogout') {
-					return 'true';
-				}
-				return $default;
-			});
-	
+			->with('globalLogout')
+			->willReturn('true');
+
 		// Mock the Authorization header for logout
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'Authorization') {
-					return 'Bearer valid-token';
-				}
-				return $default;
-			});
-		// 
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('Authorization')
+			->willReturn('Bearer valid-token');
+
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('DecodeAccessToken')
 			->with('valid-token')
 			->willReturn(['userId' => 1]);
-	
+
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('RevokeRefreshTokensByUserId')
 			->with(1);
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		$this->assertTrue($reply->Auth);
 		$this->assertEquals('Logged out globally.', $reply->Message);
 	}
 
 	public function testGetAuthenticatedUserWithMissingUserIdInClaims() {
 		// Set the Authorization header to a valid token
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'Authorization') {
-					return 'Bearer valid-token';
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('Authorization')
+			->willReturn('Bearer valid-token');
+
 		// Mock the TokenManager to decode the token without a userId
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('DecodeAccessToken')
 			->with('valid-token')
 			->willReturn([]); // No userId in claims
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->GetAuthenticatedUser($this->requestObserver);
-	
+
 		// Assert the expected error response
 		$this->assertFalse($reply->Auth);
 		$this->assertEquals('Invalid token payload.', $reply->Message);
@@ -224,97 +183,79 @@ class ApiAuthTest extends TestCase {
 
 	public function testGetAuthenticatedUserWithUserNotFound() {
 		// Set the Authorization header to a valid token
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'Authorization') {
-					return 'Bearer valid-token';
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('Authorization')
+			->willReturn('Bearer valid-token');
+
 		// Mock the TokenManager to decode the token and return valid claims
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('DecodeAccessToken')
 			->with('valid-token')
 			->willReturn(['userId' => 1]);
-	
+
 		// Mock the UserMapper to return null, simulating a user not found
 		$this->userMapperObserver
 			->expects($this->once())
 			->method('GetAuthorizedUserById')
 			->with(1)
 			->willReturn(null);
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->GetAuthenticatedUser($this->requestObserver);
-	
+
 		// Assert the expected error response
 		$this->assertFalse($reply->Auth);
 		$this->assertEquals('User not found.', $reply->Message);
 	}
 
 	public function testLogoutWithMissingAuthorizationHeader() {
-		$this->getParamSet
+		// Mock the globalLogout parameter
+		$this->requestObserver
 			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'globalLogout') {
-					return 'true'; // Enable global logout
-				}
-				return $default;
-			});
-	
+			->with('globalLogout')
+			->willReturn('true');
+
 		// Mock an empty Authorization header
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'Authorization') {
-					return null; // Simulate missing header
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('Authorization')
+			->willReturn(null);
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		// Assert the expected error response
 		$this->assertFalse($reply->Auth);
 		$this->assertEquals('Missing or invalid Authorization header.', $reply->Message);
 	}
 
 	public function testLogoutWithInvalidToken() {
-		$this->getParamSet
+		// Mock the globalLogout parameter
+		$this->requestObserver
 			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'globalLogout') {
-					return 'true'; // Enable global logout
-				}
-				return $default;
-			});
-	
+			->with('globalLogout')
+			->willReturn('true');
+
 		// Mock the Authorization header with an invalid token
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'Authorization') {
-					return 'Bearer invalid-token';
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('Authorization')
+			->willReturn('Bearer invalid-token');
+
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('DecodeAccessToken')
 			->with('invalid-token')
 			->willThrowException(new InvalidTokenException('Token is invalid or expired.'));
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		// Assert the expected error response
 		$this->assertFalse($reply->Auth);
 		$this->assertEquals('Token is invalid or expired.', $reply->Message);
@@ -322,24 +263,16 @@ class ApiAuthTest extends TestCase {
 
 	public function testLogoutWithoutGlobalFlagAndWithMissingRefreshToken() {
 		// Simulate the absence of the globalLogout parameter
-		$this->getParamSet
+		$this->requestObserver
 			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'globalLogout') {
-					return false; // No global logout
-				}
-				return $default;
-			});
-	
+			->with('globalLogout')
+			->willReturn(null);
+
 		// Simulate missing RefreshToken in both Headers and Cookies
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'RefreshToken') {
-					return null;
-				}
-				return $default;
-			});	
+		$this->requestObserver
+			->method('Headers')
+			->with('RefreshToken')
+			->willReturn(null);
 		$this->cookiesParamSet
 			->method('Get')
 			->willReturnCallback(function ($key, $default = null) {
@@ -348,11 +281,11 @@ class ApiAuthTest extends TestCase {
 				}
 				return $default;
 			});
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		// Assert the expected error response
 		$this->assertFalse($reply->Auth);
 		$this->assertEquals('Missing RefreshToken header.', $reply->Message);
@@ -360,15 +293,11 @@ class ApiAuthTest extends TestCase {
 
 	public function testLogoutWithoutGlobalFlagAndWithRefreshTokenInCookies() {
 		// Simulate the absence of the globalLogout parameter
-		$this->getParamSet
+		$this->requestObserver
 			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'globalLogout') {
-					return false; // No global logout
-				}
-				return $default;
-			});
-	
+			->with('globalLogout')
+			->willReturn(null);
+
 		// Simulate RefreshToken in Cookies
 		$this->cookiesParamSet
 			->method('Get')
@@ -382,27 +311,23 @@ class ApiAuthTest extends TestCase {
 			->expects($this->once())
 			->method('Delete')
 			->with('RefreshToken'); // Ensure the cookie is deleted
-	
+
 		// Simulate no RefreshToken in Headers
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'RefreshToken') {
-					return null; // No token in headers
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('RefreshToken')
+			->willReturn(null);
+
 		// Expect the RefreshToken to be revoked
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('RevokeRefreshToken')
 			->with('cookie-refresh-token');
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		// Assert the expected success response
 		$this->assertFalse($reply->Auth); // Logout sets Auth to false
 		$this->assertEquals('Logged out.', $reply->Message);
@@ -410,63 +335,49 @@ class ApiAuthTest extends TestCase {
 
 	public function testLogoutWithoutGlobalFlagAndWithRefreshTokenInHeaders() {
 		// Simulate the globalLogout flag being false
-		$this->getParamSet
+		$this->requestObserver
 			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'globalLogout') {
-					return false;
-				}
-				return $default;
-			});
-	
+			->with('globalLogout')
+			->willReturn(null);
+
 		// Mock the Headers to return a valid RefreshToken
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'RefreshToken') {
-					return 'valid-refresh-token';
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('RefreshToken')
+			->willReturn('valid-refresh-token');
+
 		// Expect the TokenManager to revoke the refresh token
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('RevokeRefreshToken')
 			->with('valid-refresh-token');
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		// Assert the expected success response
 		$this->assertFalse($reply->Auth); // Logout sets Auth to false
 		$this->assertEquals('Logged out.', $reply->Message);
 	}
 
 	public function testLogoutWithInvalidAuthorizationHeader() {
-		$this->getParamSet
+		// Simulate a global logout attempt
+		$this->requestObserver
 			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'globalLogout') {
-					return 'true'; // Simulate a global logout attempt
-				}
-				return $default;
-			});
-	
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'Authorization') {
-					return 'InvalidHeader'; // Simulate an invalid Authorization header
-				}
-				return $default;
-			});
-	
+			->with('globalLogout')
+			->willReturn('true');
+
+		// Mock the Authorization header to an invalid value
+		$this->requestObserver
+			->method('Headers')
+			->with('Authorization')
+			->willReturn('InvalidHeader');
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		// Assert the expected error response
 		$this->assertFalse($reply->Auth);
 		$this->assertEquals('Missing or invalid Authorization header.', $reply->Message);
@@ -474,72 +385,57 @@ class ApiAuthTest extends TestCase {
 
 	public function testLogoutWithInvalidRefreshToken() {
 		// Simulate a single-session logout (no global flag)
-		$this->getParamSet
+		$this->requestObserver
 			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'globalLogout') {
-					return false; // No global logout
-				}
-				return $default;
-			});
-	
+			->with('globalLogout')
+			->willReturn(null);
+
 		// Mock the RefreshToken header in the request
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'RefreshToken') {
-					return 'invalid-refresh-token';
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('RefreshToken')
+			->willReturn('invalid-refresh-token');
+
 		// Mock the behavior of the tokenManager to throw an exception when revoking
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('RevokeRefreshToken')
 			->with('invalid-refresh-token')
 			->willThrowException(new \Exception('Token revocation failed'));
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		// Assert the expected error response
 		$this->assertFalse($reply->Auth);
 		$this->assertEquals('Failed to log out: Token revocation failed', $reply->Message);
 	}
 
 	public function testLogoutWithNullUserIdInClaims() {
-		$this->getParamSet
+		// Simulate a global logout attempt
+		$this->requestObserver
 			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'globalLogout') {
-					return 'true'; // Simulate a global logout attempt
-				}
-				return $default;
-			});
+			->with('globalLogout')
+			->willReturn('true');
 
 		// Set the Authorization header to a valid token
-		$this->headersParamSet
-			->method('Get')
-			->willReturnCallback(function ($key, $default = null) {
-				if ($key === 'Authorization') {
-					return 'Bearer valid-token';
-				}
-				return $default;
-			});
-	
+		$this->requestObserver
+			->method('Headers')
+			->with('Authorization')
+			->willReturn('Bearer valid-token');
+
 		// Mock the TokenManager to decode the token with a null userId
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('DecodeAccessToken')
 			->with('valid-token')
 			->willReturn(['userId' => null]); // Explicit null for userId
-	
+
 		$auth = new ApiAuth($this->userMapperObserver, $this->tokenManagerObserver);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		// Assert the expected error response
 		$this->assertFalse($reply->Auth);
 		$this->assertEquals('Invalid token payload.', $reply->Message);

--- a/tests/Auth/WebAuthTestSetup.php
+++ b/tests/Auth/WebAuthTestSetup.php
@@ -5,10 +5,10 @@ namespace Fluxoft\Rebar\Auth;
 use Fluxoft\Rebar\Auth\TokenManager;
 use Fluxoft\Rebar\Auth\UserInterface;
 use Fluxoft\Rebar\Auth\UserMapperInterface;
-use Fluxoft\Rebar\Http\ParameterSet;
+use Fluxoft\Rebar\Http\Cookies;
 use Fluxoft\Rebar\Http\Request;
+use Fluxoft\Rebar\Http\Session;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
 trait WebAuthTestSetup {
 	/** @var UserMapperInterface|MockObject */
@@ -19,25 +19,15 @@ trait WebAuthTestSetup {
 	private $userObserver;
 	/** @var Request|MockObject */
 	private $requestObserver;
-	/** @var ParameterSet|MockObject */
-	private $headersParamSet;
-	/** @var ParameterSet|MockObject */
-	private $getParamSet;
-	/** @var ParameterSet|MockObject */
+	/** @var Cookies|MockObject */
 	private $cookiesParamSet;
-	/** @var ParameterSet|MockObject */
+	/** @var Session|MockObject */
 	private $sessionParamSet;
 
 	protected function setUp(): void {
 		$this->userMapperObserver   = $this->getMockBuilder('\Fluxoft\Rebar\Auth\UserMapperInterface')
 			->getMock();
 		$this->userObserver         = $this->getMockBuilder('\Fluxoft\Rebar\Auth\UserInterface')
-			->getMock();
-		$this->headersParamSet      = $this->getMockBuilder('\Fluxoft\Rebar\Http\ParameterSet')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->getParamSet          = $this->getMockBuilder('\Fluxoft\Rebar\Http\ParameterSet')
-			->disableOriginalConstructor()
 			->getMock();
 		$this->cookiesParamSet      = $this->getMockBuilder('\Fluxoft\Rebar\Http\ParameterSet')
 			->disableOriginalConstructor()
@@ -47,21 +37,15 @@ trait WebAuthTestSetup {
 			->getMock();
 		$this->tokenManagerObserver = $this->getMockBuilder('\Fluxoft\Rebar\Auth\TokenManager')
 			->disableOriginalConstructor()
-			->getMock();	
+			->getMock();
 		$this->requestObserver      = $this->getMockBuilder('\Fluxoft\Rebar\Http\Request')
 			->disableOriginalConstructor()
 			->getMock();
-	
+
 		// Mock the Request::__get method to return the Headers, Cookies, and Session parameter sets
 		$this->requestObserver
 			->method('__get')
 			->willReturnCallback(function ($key) {
-				if ($key === 'Headers') {
-					return $this->headersParamSet;
-				}
-				if ($key === 'Get') {
-					return $this->getParamSet;
-				}
 				if ($key === 'Cookies') {
 					return $this->cookiesParamSet;
 				}
@@ -77,8 +61,7 @@ trait WebAuthTestSetup {
 			$this->userMapperObserver,
 			$this->tokenManagerObserver,
 			$this->userObserver,
-			$this->requestObserver,
-			$this->headersParamSet
+			$this->requestObserver
 		);
 	}
 }

--- a/tests/Auth/WebAuth_LogoutTest.php
+++ b/tests/Auth/WebAuth_LogoutTest.php
@@ -17,7 +17,7 @@ class WebAuth_LogoutTest extends \PHPUnit\Framework\TestCase {
 			->willReturnCallback(function ($key) use (&$deletedCookies) {
 				$deletedCookies[] = $key;
 			});
-	
+
 		$deletedSession = [];
 		$this->sessionParamSet
 			->expects($this->exactly(2))
@@ -25,19 +25,19 @@ class WebAuth_LogoutTest extends \PHPUnit\Framework\TestCase {
 			->willReturnCallback(function ($key) use (&$deletedSession) {
 				$deletedSession[] = $key;
 			});
-	
+
 		$this->tokenManagerObserver
 			->expects($this->never())
 			->method('RevokeRefreshToken');
-	
+
 		$this->tokenManagerObserver
 			->expects($this->never())
 			->method('RevokeRefreshTokensByUserId');
-	
+
 		$auth = new WebAuth($this->userMapperObserver, $this->tokenManagerObserver, true);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		$this->assertFalse($reply->Auth, 'Expected Auth to be false.');
 		$this->assertEquals('User logged out from this session.', $reply->Message, 'Expected the default logout message.');
 		$this->assertEquals(['AccessToken', 'RefreshToken'], $deletedCookies, 'Expected cookies to be deleted.');
@@ -49,25 +49,25 @@ class WebAuth_LogoutTest extends \PHPUnit\Framework\TestCase {
 		$this->sessionParamSet
 			->expects($this->never())
 			->method('Delete');
-	
+
 		// Mock the cookies to simulate token deletion
 		$this->cookiesParamSet
 			->expects($this->exactly(2))
 			->method('Delete')
 			->withConsecutive(['AccessToken'], ['RefreshToken']);
-	
+
 		$this->tokenManagerObserver
 			->expects($this->never())
 			->method('RevokeRefreshToken');
-	
+
 		$this->tokenManagerObserver
 			->expects($this->never())
 			->method('RevokeRefreshTokensByUserId');
-	
+
 		$auth = new WebAuth($this->userMapperObserver, $this->tokenManagerObserver, false);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		$this->assertFalse($reply->Auth, 'Expected Auth to be false.');
 		$this->assertEquals('User logged out from this session.', $reply->Message, 'Expected the default logout message.');
 	}
@@ -80,7 +80,7 @@ class WebAuth_LogoutTest extends \PHPUnit\Framework\TestCase {
 			->willReturnCallback(function ($key) use (&$deletedCookies) {
 				$deletedCookies[] = $key;
 			});
-	
+
 		$deletedSession = [];
 		$this->sessionParamSet
 			->expects($this->exactly(2))
@@ -88,25 +88,25 @@ class WebAuth_LogoutTest extends \PHPUnit\Framework\TestCase {
 			->willReturnCallback(function ($key) use (&$deletedSession) {
 				$deletedSession[] = $key;
 			});
-	
+
 		$this->cookiesParamSet
 			->method('Get')
 			->with('RefreshToken')
 			->willReturn('valid-refresh-token');
-	
+
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('RevokeRefreshToken')
 			->with('valid-refresh-token');
-	
+
 		$this->tokenManagerObserver
 			->expects($this->never())
 			->method('RevokeRefreshTokensByUserId');
-	
+
 		$auth = new WebAuth($this->userMapperObserver, $this->tokenManagerObserver, true);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		$this->assertFalse($reply->Auth, 'Expected Auth to be false.');
 		$this->assertEquals('User logged out from this session.', $reply->Message, 'Expected the logout message.');
 		$this->assertEquals(['AccessToken', 'RefreshToken'], $deletedCookies, 'Expected cookies to be deleted.');
@@ -121,7 +121,7 @@ class WebAuth_LogoutTest extends \PHPUnit\Framework\TestCase {
 			->willReturnCallback(function ($key) use (&$deletedCookies) {
 				$deletedCookies[] = $key;
 			});
-	
+
 		$deletedSession = [];
 		$this->sessionParamSet
 			->expects($this->exactly(2))
@@ -129,38 +129,38 @@ class WebAuth_LogoutTest extends \PHPUnit\Framework\TestCase {
 			->willReturnCallback(function ($key) use (&$deletedSession) {
 				$deletedSession[] = $key;
 			});
-	
+
 		$this->cookiesParamSet
 			->method('Get')
 			->with('RefreshToken')
 			->willReturn('valid-refresh-token');
-	
-		$this->getParamSet
+
+		$this->requestObserver
 			->method('Get')
 			->with('globalLogout', false)
 			->willReturn(true);
-	
+
 		$this->tokenManagerObserver
 			->expects($this->once())
 			->method('RevokeRefreshTokensByUserId')
 			->with(1);
-	
+
 		$this->tokenManagerObserver
 			->expects($this->never())
 			->method('RevokeRefreshToken');
-	
+
 		$this->userMapperObserver
 			->expects($this->never())
 			->method('GetAuthorizedUserById');
-	
+
 		$this->tokenManagerObserver
 			->method('DecodeAccessToken')
 			->willReturn(['userId' => 1]);
-	
+
 		$auth = new WebAuth($this->userMapperObserver, $this->tokenManagerObserver, true);
-	
+
 		$reply = $auth->Logout($this->requestObserver);
-	
+
 		$this->assertFalse($reply->Auth, 'Expected Auth to be false.');
 		$this->assertEquals('User logged out from all devices.', $reply->Message, 'Expected the global logout message.');
 		$this->assertEquals(['AccessToken', 'RefreshToken'], $deletedCookies, 'Expected cookies to be deleted.');


### PR DESCRIPTION
As part of getting phpdoc up and running, added phpstan ruleset to the project to validate phpdoc annotation blocks, which led to finding and fixing several problems revealed by the tests showing that underlying classes were incorrectly implementing Request::Headers(), Request::Get(), etc.

Added a PHPStan checker to the CircleCI build to enforce code quality using this tool.