### PR TITLE
Feature/1.1.1 config class array merge recursive fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.1] - 2025-01-20
+### Fixed
+- Fixed issue with `Config` class where nested arrays were replaced instead of merged when multiple configuration sources were loaded. Arrays are now merged recursively rather than shallow-merged.
+
 ## [1.1.0] - 2025-01-15
 ### Deprecated
 - `Controller::set()` has been deprecated. Use `$this->response->SetData()` instead.
@@ -55,6 +59,7 @@ Unlike [0.24.0], this isn't just a release candidate for masochists. It's ready 
 - This version marked the final "beta" release before stabilizing for 1.0.0.
 - Numerous features were explored, tested, and refined leading up to this release.
 
+[1.1.1]: https://github.com/fluxoft/rebar/releases/tag/1.1.1
 [1.1.0]: https://github.com/fluxoft/rebar/releases/tag/1.1.0
 [1.0.0]: https://github.com/fluxoft/rebar/releases/tag/1.0.0
 [0.25.3]: https://github.com/fluxoft/rebar/releases/tag/0.25.3

--- a/docs/1.x/configuration.md
+++ b/docs/1.x/configuration.md
@@ -57,6 +57,16 @@ The `Config` class processes the sources in the order specified in its construct
 
 The configuration merging prioritizes sources in the order they are provided in the `$sources` array. For example, if both a `.json` file and environment variables define a `DB_HOST`, the value from environment variables will take precedence if `env` is processed later.
 
+### Merging Sources
+
+The `Config` class processes configuration sources in the order they are specified in the `$sources` array. Starting from version `1.1.1`, sources are merged recursively.
+
+#### Updated Behavior
+
+In prior versions, the `Config` class used `array_merge()` for merging, which replaced entire arrays when duplicate keys were encountered. As of version `1.1.1`, it uses `array_replace_recursive()`, ensuring that nested arrays are merged key by key. This allows configuration sources to override specific nested keys without affecting unrelated values.
+
+This change improves flexibility while maintaining backward compatibility.
+
 ## Loading Configuration from Specific Sources
 
 Here is how the `ConfigSourcesLoader` processes various source types:

--- a/src/Config.php
+++ b/src/Config.php
@@ -103,6 +103,6 @@ class Config implements \ArrayAccess {
 	}
 
 	private function mergeProperties(array $newProperties): void {
-		$this->properties = array_merge($this->properties, $newProperties);
+		$this->properties = array_replace_recursive($this->properties, $newProperties);
 	}
 }

--- a/tests/Http/RouterTest.php
+++ b/tests/Http/RouterTest.php
@@ -614,7 +614,6 @@ class TestRouter extends Router {
 // TestRouter with overridden route method
 class TestRouterGetRouteThrowsException extends Router {
 	protected function getRoute(string $path) {
-		echo "calling TestRouterGetRouteThrowsException::getRoute\n";
 		throw new RouterException('Route not found', 404);
 	}
 }


### PR DESCRIPTION
## [1.1.1] - 2025-01-20
### Fixed
- Fixed issue with `Config` class where nested arrays were replaced instead of merged when multiple configuration sources were loaded.