### PR TITLE
1.1.3 Enhance value formatting in PostgresMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.3] - 2025-02-03
+### Fixed
+- Enhance PostgresMapper to propertly handle DateTime objects directly and improve test coverage for
+date/time formatting
+
 ## [1.1.2] - 2025-02-01
 ### Fixed
 - Fixed issue with mapper classes where comparisons to null values needs special handling. When creating a
@@ -67,6 +72,7 @@ Unlike [0.24.0], this isn't just a release candidate for masochists. It's ready 
 - This version marked the final "beta" release before stabilizing for 1.0.0.
 - Numerous features were explored, tested, and refined leading up to this release.
 
+[1.1.3]: https://github.com/fluxoft/rebar/releases/tag/1.1.3
 [1.1.2]: https://github.com/fluxoft/rebar/releases/tag/1.1.2
 [1.1.1]: https://github.com/fluxoft/rebar/releases/tag/1.1.1
 [1.1.0]: https://github.com/fluxoft/rebar/releases/tag/1.1.0

--- a/src/Data/Db/Mappers/PostgresMapper.php
+++ b/src/Data/Db/Mappers/PostgresMapper.php
@@ -30,8 +30,23 @@ abstract class PostgresMapper extends GenericSqlMapper {
 	 * @return mixed
 	 */
 	protected function formatValueForInsert(string $type, mixed $value): mixed {
-		if (is_string($value)) {
-			// Attempt to parse strings into DateTime objects and reformat
+		// Handle DateTime objects directly
+		if ($value instanceof \DateTime) {
+			switch ($type) {
+				case 'datetime': // @codeCoverageIgnore
+					return $value->format('Y-m-d H:i:s');
+				case 'date': // @codeCoverageIgnore
+					return $value->format('Y-m-d');
+				case 'time': // @codeCoverageIgnore
+					return $value->format('H:i:s');
+				default:
+					// If the type is not a date/time type, use the base class logic
+					return parent::formatValueForInsert($type, $value);
+			}
+		}
+
+		// Attempt to parse strings into DateTime objects and reformat
+		if (in_array($type, ['datetime', 'date', 'time']) && is_string($value)) {
 			$dateTime = \DateTime::createFromFormat('Y-m-d H:i:s', $value) ?:
 						\DateTime::createFromFormat('Y-m-d', $value) ?:
 						\DateTime::createFromFormat('H:i:s', $value) ?:

--- a/tests/Data/Db/Mappers/PostgresMapperTest.php
+++ b/tests/Data/Db/Mappers/PostgresMapperTest.php
@@ -37,7 +37,7 @@ class PostgresMapperTest extends TestCase {
 	/**
 	 * @dataProvider formatValueForInsertProvider
 	 */
-	public function testFormatValueForInsert(string $type, mixed $value, mixed $expected) {
+	public function testFormatValueForInsert(string $type, mixed $value, mixed $expected, string $exceptionMessage = null) {
 		/** @var MapperFactory $mapperFactory */
 		$mapperFactory = $this->getMockBuilder(MapperFactory::class)
 			->disableOriginalConstructor()
@@ -59,7 +59,11 @@ class PostgresMapperTest extends TestCase {
 
 		if ($expected === 'InvalidArgumentException') {
 			$this->expectException(\InvalidArgumentException::class);
-			$this->expectExceptionMessage("Invalid date/time format for value '$value'");
+			if ($exceptionMessage) {
+				$this->expectExceptionMessage($exceptionMessage);
+			} else {
+				$this->expectExceptionMessage("Invalid date/time format for value '$value'");
+			}
 		}
 
 		$actual = $postgres->PublicFormatValueForInsert($type, $value);
@@ -92,6 +96,37 @@ class PostgresMapperTest extends TestCase {
 				'type'     => 'datetime',
 				'value'    => new \DateTime('2024-12-31 15:30:00'),
 				'expected' => '2024-12-31 15:30:00'
+			],
+			'DateTime object for date type' => [
+				'type'     => 'date',
+				'value'    => new \DateTime('2024-12-31 15:30:00'),
+				'expected' => '2024-12-31'
+			],
+			'DateTime object for time type' => [
+				'type'     => 'time',
+				'value'    => new \DateTime('2024-12-31 15:30:00'),
+				'expected' => '15:30:00'
+			],
+			'DateTime object for non-date/time type' => [
+				'type'     => 'varchar',
+				'value'    => new \DateTime('2024-12-31 15:30:00'),
+				'expected' => 'InvalidArgumentException',
+				'exceptionMessage' => 'Cannot format DateTime object as type: varchar'
+			],
+			'Invalid date string' => [
+				'type'     => 'date',
+				'value'    => 'invalid-date',
+				'expected' => 'InvalidArgumentException'
+			],
+			'Invalid time string' => [
+				'type'     => 'time',
+				'value'    => 'invalid-time',
+				'expected' => 'InvalidArgumentException'
+			],
+			'Non-date/time string for non-date/time type' => [
+				'type'     => 'varchar',
+				'value'    => 'TheQuickBrownFixJumpsOverTheLazyDog',
+				'expected' => 'TheQuickBrownFixJumpsOverTheLazyDog'
 			]
 		];
 	}

--- a/tests/Data/Db/Mappers/PostgresMapperTest.php
+++ b/tests/Data/Db/Mappers/PostgresMapperTest.php
@@ -37,7 +37,12 @@ class PostgresMapperTest extends TestCase {
 	/**
 	 * @dataProvider formatValueForInsertProvider
 	 */
-	public function testFormatValueForInsert(string $type, mixed $value, mixed $expected, string $exceptionMessage = null) {
+	public function testFormatValueForInsert(
+		string $type,
+		mixed $value,
+		mixed $expected,
+		string $exceptionMessage = null
+	) {
 		/** @var MapperFactory $mapperFactory */
 		$mapperFactory = $this->getMockBuilder(MapperFactory::class)
 			->disableOriginalConstructor()


### PR DESCRIPTION
1.1.3 Enhance PostgresMapper to handle DateTime objects directly and improve test coverage for date/time formatting