### PR TITLE
Change SeriesId property type from int to string in RefreshToken model

### DIFF
--- a/src/Auth/RefreshToken.php
+++ b/src/Auth/RefreshToken.php
@@ -9,7 +9,7 @@ use Fluxoft\Rebar\Model;
  * A model for a refresh token.
  * @property int $Id
  * @property int $UserId
- * @property int $SeriesId
+ * @property string $SeriesId
  * @property string $Token
  * @property string $ExpiresAt
  * @property string $CreatedAt
@@ -19,7 +19,7 @@ class RefreshToken extends Model {
 	protected static array $defaultProperties = [
 		'Id'        => 0,
 		'UserId'    => 0,
-		'SeriesId'  => 0,
+		'SeriesId'  => '',
 		'Token'     => null,
 		'ExpiresAt' => null,
 		'CreatedAt' => null,


### PR DESCRIPTION
because the SeriesId is generated using uniqid('', true), which produces a string output.